### PR TITLE
Modifications to artists model for bn-api pr 3

### DIFF
--- a/src/models/artists.rs
+++ b/src/models/artists.rs
@@ -6,7 +6,7 @@ use utils::errors::DatabaseError;
 use utils::errors::ErrorCode;
 use uuid::Uuid;
 
-#[derive(Associations, Identifiable, Queryable, Serialize)]
+#[derive(Associations, Deserialize, Identifiable, Queryable, Serialize)]
 pub struct Artist {
     pub id: Uuid,
     pub name: String,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,8 +5,8 @@ pub use self::events::Event;
 pub use self::orders::Order;
 pub use self::organization_users::OrganizationUser;
 pub use self::organization_venues::OrganizationVenue;
-pub use self::roles::Roles;
 pub use self::organizations::*;
+pub use self::roles::Roles;
 pub use self::users::User;
 pub use self::venues::Venue;
 


### PR DESCRIPTION
This modification is to support a bn-api branch:
https://github.com/big-neon/bn-api/pull/3

In the latest commits to that PR I added some additional tests for artists controller actions of the API. It's helpful to be able to deserialize the Artist back out from the returned responses as I can quickly inspect a created record.

Let me know if you think it's not worth it though. I can access the json directly just felt a bit cleaner to deserialize as it was only a single macro away and the serde interface for it is pretty straightforward.