### PR TITLE
Modifications to DB crate for API PR#23, User::find functionality

### DIFF
--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -52,6 +52,14 @@ impl User {
         }
     }
 
+    pub fn find(id: &Uuid, conn: &Connectable) -> Result<User, DatabaseError> {
+        DatabaseError::wrap(
+            ErrorCode::QueryError,
+            "Error loading user",
+            users::table.find(id).first::<User>(conn.get_connection()),
+        )
+    }
+
     pub fn find_by_email(email: &str, conn: &Connectable) -> Result<User, DatabaseError> {
         DatabaseError::wrap(
             ErrorCode::QueryError,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,7 @@
 extern crate bigneon_db;
 extern crate diesel;
 extern crate dotenv;
+extern crate uuid;
 
 mod support;
 mod unit;

--- a/tests/unit/artists.rs
+++ b/tests/unit/artists.rs
@@ -1,5 +1,6 @@
 use bigneon_db::models::{Artist, NewArtist};
 use support::project::TestProject;
+use uuid::Uuid;
 
 #[test]
 fn commit() {
@@ -13,14 +14,23 @@ fn commit() {
 #[test]
 fn find() {
     let project = TestProject::new();
-    let name = "Name";
-    let artist = Artist::create(&name).commit(&project).unwrap();
-    assert_eq!(name, artist.name);
-    assert_eq!(artist.id.to_string().is_empty(), false);
+    let artist = Artist::create("Name").commit(&project).unwrap();
 
-    let found_artist = Artist::find(&artist.id, &project).unwrap();
+    let found_artist = match Artist::find(&artist.id, &project) {
+        Ok(artist) => artist,
+        Err(_e) => panic!("Artist was not found"),
+    };
     assert_eq!(found_artist.id, artist.id);
     assert_eq!(found_artist.name, artist.name);
+
+    let invalid_artist = match Artist::find(&Uuid::new_v4(), &project) {
+        Ok(_artist) => false,
+        Err(_e) => true,
+    };
+    assert!(
+        invalid_artist,
+        "Artist incorrectly returned when id invalid"
+    );
 }
 
 #[test]

--- a/tests/unit/users.rs
+++ b/tests/unit/users.rs
@@ -1,5 +1,6 @@
 use bigneon_db::models::User;
 use support::project::TestProject;
+use uuid::Uuid;
 
 #[test]
 fn commit() {
@@ -18,6 +19,27 @@ fn commit() {
     assert_ne!(user.hashed_pw, password);
     assert_eq!(user.hashed_pw.is_empty(), false);
     assert_eq!(user.id.to_string().is_empty(), false);
+}
+
+#[test]
+fn find() {
+    let project = TestProject::new();
+    let user = User::create("Jeff", "jeff@tari.com", "555-555-5555", "examplePassword")
+        .commit(&project)
+        .unwrap();
+
+    let found_user = match User::find(&user.id, &project) {
+        Ok(user) => user,
+        Err(_e) => panic!("User was not found"),
+    };
+    assert_eq!(found_user.id, user.id);
+    assert_eq!(found_user.email, user.email);
+
+    let invalid_user = match User::find(&Uuid::new_v4(), &project) {
+        Ok(_user) => false,
+        Err(_e) => true,
+    };
+    assert!(invalid_user, "User incorrectly returned when id invalid");
 }
 
 #[test]


### PR DESCRIPTION
Some more minor changes to support the sessions PR on the API side: https://github.com/big-neon/bn-api/pull/23

Mostly just adds User::find (w/ its test) and refactors the Artist::find method to flesh it out more with a negative case.