### PR TITLE
Refresh tokens

### DIFF
--- a/migrations/00000000000002_users/up.sql
+++ b/migrations/00000000000002_users/up.sql
@@ -5,6 +5,7 @@ CREATE TABLE users (
   email TEXT NOT NULL UNIQUE,
   phone TEXT NOT NULL,
   hashed_pw TEXT NOT NULL,
+  password_modified_at TIMESTAMP NOT NULL DEFAULT now(),
   created_at TIMESTAMP NOT NULL DEFAULT now(),
   last_used TIMESTAMP DEFAULT NULL,
   active BOOLEAN NOT NULL DEFAULT 't',

--- a/src/models/concerns/users/password_resetable.rs
+++ b/src/models/concerns/users/password_resetable.rs
@@ -45,6 +45,7 @@ impl PasswordResetable for User {
             Ok(user) => {
                 if user.has_valid_password_reset_token() {
                     let hash = PasswordHash::generate(password, None);
+                    let now = Utc::now().naive_utc();
 
                     DatabaseError::wrap(
                         ErrorCode::UpdateError,
@@ -52,6 +53,7 @@ impl PasswordResetable for User {
                         diesel::update(users.filter(id.eq(user.id)))
                             .set((
                                 hashed_pw.eq(&hash.to_string()),
+                                password_modified_at.eq(now),
                                 PasswordReset {
                                     password_reset_token: None,
                                     password_reset_requested_at: None,

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -25,6 +25,7 @@ pub struct User {
     pub email: String,
     pub phone: String,
     pub hashed_pw: String,
+    pub password_modified_at: NaiveDateTime,
     pub created_at: NaiveDateTime,
     pub last_used: Option<NaiveDateTime>,
     pub active: bool,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -59,20 +59,6 @@ table! {
 }
 
 table! {
-    organizations (id) {
-        id -> Uuid,
-        owner_user_id -> Uuid,
-        name -> Text,
-        address -> Nullable<Text>,
-        city -> Nullable<Text>,
-        state -> Nullable<Text>,
-        country -> Nullable<Text>,
-        zip -> Nullable<Text>,
-        phone -> Nullable<Text>,
-    }
-}
-
-table! {
     organization_users (id) {
         id -> Uuid,
         organization_id -> Uuid,
@@ -89,12 +75,27 @@ table! {
 }
 
 table! {
+    organizations (id) {
+        id -> Uuid,
+        owner_user_id -> Uuid,
+        name -> Text,
+        address -> Nullable<Text>,
+        city -> Nullable<Text>,
+        state -> Nullable<Text>,
+        country -> Nullable<Text>,
+        zip -> Nullable<Text>,
+        phone -> Nullable<Text>,
+    }
+}
+
+table! {
     users (id) {
         id -> Uuid,
         name -> Text,
         email -> Text,
         phone -> Text,
         hashed_pw -> Text,
+        password_modified_at -> Timestamp,
         created_at -> Timestamp,
         last_used -> Nullable<Timestamp>,
         active -> Bool,
@@ -140,9 +141,9 @@ allow_tables_to_appear_in_same_query!(
     events,
     orders,
     organization_invites,
-    organizations,
     organization_users,
     organization_venues,
+    organizations,
     users,
     venues,
 );


### PR DESCRIPTION
This is the DB branch related to [issue 31 from the bn-api repository](https://github.com/big-neon/bn-api/issues/31).

In this branch I added a `password_modified_at` field which is used to keep track of the last time a password is modified. We needed some way to invalidate the long lasting refresh tokens in the event the user changes their password as otherwise a given unauthorized user would never lose access. The refresh token claims has an issued timestamp which is compared and if it was issued prior to the password change the user is forced to login again.

We don't currently have an endpoint to update a given user's password aside via the password reset flow so I've only modified the password reset flow to set the password modified date. We'll need to make sure when we add the ability to change passwords for a given user from their account endpoint that we also update this timestamp.

