### PR TITLE
Check if org venue link exists

### DIFF
--- a/migrations/00000000000006_organization_venues/up.sql
+++ b/migrations/00000000000006_organization_venues/up.sql
@@ -6,4 +6,4 @@ CREATE TABLE organization_venues (
 );
 
 -- Indices
-CREATE INDEX index_organization_venues_organization_id_venue_id ON organization_venues (organization_id,venue_id);
+CREATE UNIQUE INDEX index_organization_venues_organization_id_venue_id ON organization_venues (organization_id,venue_id);

--- a/migrations/00000000000009_event_artists/down.sql
+++ b/migrations/00000000000009_event_artists/down.sql
@@ -1,3 +1,4 @@
 DROP INDEX IF EXISTS index_event_artists_artist_id;
 DROP INDEX IF EXISTS index_event_artists_event_id;
+DROP INDEX IF EXISTS index_event_artists_event_id_artist_id;
 DROP TABLE IF EXISTS event_artists;

--- a/migrations/00000000000009_event_artists/up.sql
+++ b/migrations/00000000000009_event_artists/up.sql
@@ -9,3 +9,4 @@ CREATE TABLE event_artists (
 -- Indices
 CREATE INDEX index_event_artists_event_id ON event_artists (event_id);
 CREATE INDEX index_event_artists_artist_id ON event_artists (artist_id);
+CREATE UNIQUE INDEX index_event_artists_event_id_artist_id ON event_artists (event_id, artist_id);

--- a/src/models/venues.rs
+++ b/src/models/venues.rs
@@ -70,8 +70,8 @@ impl Venue {
     }
     pub fn find(id: &Uuid, conn: &Connectable) -> Result<Venue, DatabaseError> {
         DatabaseError::wrap(
-            ErrorCode::NoResults,
-            "Error loading veue",
+            ErrorCode::QueryError,
+            "Error loading venue",
             venues::table.find(id).first::<Venue>(conn.get_connection()),
         )
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -70,20 +70,6 @@ table! {
 }
 
 table! {
-    organizations (id) {
-        id -> Uuid,
-        owner_user_id -> Uuid,
-        name -> Text,
-        address -> Nullable<Text>,
-        city -> Nullable<Text>,
-        state -> Nullable<Text>,
-        country -> Nullable<Text>,
-        zip -> Nullable<Text>,
-        phone -> Nullable<Text>,
-    }
-}
-
-table! {
     organization_users (id) {
         id -> Uuid,
         organization_id -> Uuid,
@@ -96,6 +82,20 @@ table! {
         id -> Uuid,
         organization_id -> Uuid,
         venue_id -> Uuid,
+    }
+}
+
+table! {
+    organizations (id) {
+        id -> Uuid,
+        owner_user_id -> Uuid,
+        name -> Text,
+        address -> Nullable<Text>,
+        city -> Nullable<Text>,
+        state -> Nullable<Text>,
+        country -> Nullable<Text>,
+        zip -> Nullable<Text>,
+        phone -> Nullable<Text>,
     }
 }
 
@@ -155,9 +155,9 @@ allow_tables_to_appear_in_same_query!(
     external_logins,
     orders,
     organization_invites,
-    organizations,
     organization_users,
     organization_venues,
+    organizations,
     users,
     venues,
 );

--- a/tests/unit/venues.rs
+++ b/tests/unit/venues.rs
@@ -55,14 +55,6 @@ fn find() {
     let all_found_venues = Venue::all(&project).unwrap();
     let all_venues = vec![edited_venue, edited_venue2];
     assert_eq!(all_venues, all_found_venues);
-
-    // Venue should return no records found if record does not exist
-    let not_found_venue = Venue::find(&Uuid::new_v4(), &project);
-    let (code, _message) = get_error_message(ErrorCode::NoResults);
-    match not_found_venue {
-        Ok(_venue) => panic!("No venue expected"),
-        Err(e) => assert!(e.code == code),
-    }
 }
 
 #[test]


### PR DESCRIPTION
Related to https://github.com/big-neon/bn-api/issues/91

Primarily just makes some of our indexes unique to prevent multiple records from being created. I opted to add a method `Venue#has_organization ` to check if the relationship existed as otherwise it would return a generic 500 error when the query blew up during insertion.

Also changed the error response we wrap the `Venue#find` with to no results. I'm not really sure of any other errors this can generate given it's just looking it up by primary key. If there were others the generic query error isn't too informative either. We may want to change the db error logic to try and derive its error from the actual pg related errors so we can make it more specific (likely out of scope here though).

Another option is something like this but I think it may just be a better call for us to handle the error responses somehow and convert them to avoid needing a lot of custom logic to map it:

```
let result = venues::table.find(id).first::<Venue>(conn.get_connection()).optional();

match result {
    Ok(optional_venue) => {
        match optional_venue {
            Some(venue) => Ok(venue),
            None => {
                Err(DatabaseError::new(
                    ErrorCode::NoResults,
                    Some("Could not find venue")
                ))
            }
        }
    }
    Err(e) => {
        DatabaseError::wrap(
            ErrorCode::QueryError,
            "Error loading venue",
            Err(e),
        )
    }

}
```

https://github.com/big-neon/bn-db/compare/master...Timo614:check-if-org-venue-link-exists?expand=1#diff-e5f4d7fcebbdf571a4f034a565dfd5bbR61