### PR TITLE
Lock down event update parameters

### DIFF
--- a/src/models/organizations.rs
+++ b/src/models/organizations.rs
@@ -42,7 +42,7 @@ impl NewOrganization {
     }
 }
 
-#[derive(AsChangeset, Deserialize)]
+#[derive(AsChangeset, Default, Deserialize)]
 #[table_name = "organizations"]
 pub struct OrganizationEditableAttributes {
     pub name: Option<String>,
@@ -52,20 +52,6 @@ pub struct OrganizationEditableAttributes {
     pub country: Option<String>,
     pub zip: Option<String>,
     pub phone: Option<String>,
-}
-
-impl OrganizationEditableAttributes {
-    pub fn new() -> OrganizationEditableAttributes {
-        OrganizationEditableAttributes {
-            name: None,
-            address: None,
-            city: None,
-            state: None,
-            country: None,
-            zip: None,
-            phone: None,
-        }
-    }
 }
 
 impl Organization {

--- a/tests/support/organization_builder.rs
+++ b/tests/support/organization_builder.rs
@@ -46,7 +46,7 @@ impl<'a> OrganizationBuilder<'a> {
                 .unwrap();
         }
         if self.use_address {
-            let mut attrs = OrganizationEditableAttributes::new();
+            let mut attrs: OrganizationEditableAttributes = Default::default();
 
             attrs.address = Some(<String>::from("Test Address"));
             attrs.city = Some(<String>::from("Test Address"));

--- a/tests/unit/organizations.rs
+++ b/tests/unit/organizations.rs
@@ -29,7 +29,7 @@ fn update() {
     edited_organization.zip = Some("0124".to_string());
     edited_organization.phone = Some("+27123456789".to_string());
 
-    let mut changed_attrs = OrganizationEditableAttributes::new();
+    let mut changed_attrs: OrganizationEditableAttributes = Default::default();
     changed_attrs.name = Some("Test Org".to_string());
     changed_attrs.address = Some("Test Address".to_string());
     changed_attrs.city = Some("Test Address".to_string());


### PR DESCRIPTION
Relates to https://github.com/big-neon/bn-api/issues/87

This is the db side of changes to support the associated API issue. Switched the logic to use the pattern we've been using for updating the attributes of a given model and removed some of the fields which didn't make sense for the user to be able to modify (id, created_at).