### PR TITLE
Separate user name into first and last names

### DIFF
--- a/migrations/00000000000002_users/up.sql
+++ b/migrations/00000000000002_users/up.sql
@@ -1,7 +1,8 @@
 -- Define the users table
 CREATE TABLE users (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-  name TEXT NOT NULL,
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL,
   email TEXT NULL UNIQUE,
   phone TEXT NULL,
   hashed_pw TEXT NOT NULL,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -132,7 +132,7 @@ fn create_db_and_user(matches: &ArgMatches) {
     println!("Creating user");
 
     let db_connection = DatabaseConnection::new(conn_string).unwrap();
-    let user = models::User::create("System Administrator", username, phone, password)
+    let user = models::User::create("System", "Administrator", username, phone, password)
         .commit(&db_connection)
         .expect("Failed to create system admin");
     user.add_role(Roles::Admin, &db_connection)

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 #[derive(Insertable, PartialEq, Debug)]
 #[table_name = "users"]
 pub struct NewUser {
-    pub name: String,
+    pub first_name: String,
+    pub last_name: String,
     pub email: Option<String>,
     pub phone: Option<String>,
     pub hashed_pw: String,
@@ -22,7 +23,8 @@ pub struct NewUser {
 #[derive(Queryable, Identifiable, PartialEq, Debug, Clone)]
 pub struct User {
     pub id: Uuid,
-    pub name: String,
+    pub first_name: String,
+    pub last_name: String,
     pub email: Option<String>,
     pub phone: Option<String>,
     pub hashed_pw: String,
@@ -38,7 +40,8 @@ pub struct User {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct DisplayUser {
     pub id: Uuid,
-    pub name: String,
+    pub first_name: String,
+    pub last_name: String,
     pub email: Option<String>,
     pub phone: Option<String>,
     pub created_at: NaiveDateTime,
@@ -54,10 +57,17 @@ impl NewUser {
 }
 
 impl User {
-    pub fn create(name: &str, email: &str, phone: &str, password: &str) -> NewUser {
+    pub fn create(
+        first_name: &str,
+        last_name: &str,
+        email: &str,
+        phone: &str,
+        password: &str,
+    ) -> NewUser {
         let hash = PasswordHash::generate(password, None);
         NewUser {
-            name: String::from(name),
+            first_name: String::from(first_name),
+            last_name: String::from(last_name),
             email: Some(String::from(email)),
             phone: Some(String::from(phone)),
             hashed_pw: hash.to_string(),
@@ -108,6 +118,10 @@ impl User {
         self.into()
     }
 
+    pub fn full_name(&self) -> String {
+        vec![self.first_name.to_string(), self.last_name.to_string()].join(" ")
+    }
+
     pub fn add_external_login(
         &self,
         external_user_id: String,
@@ -126,7 +140,8 @@ impl User {
     ) -> Result<User, DatabaseError> {
         let hash = PasswordHash::generate("random", None);
         let new_user = NewUser {
-            name: String::from("Unknown"),
+            first_name: String::from("Unknown"),
+            last_name: String::from("Unknown"),
             email: None,
             phone: None,
             hashed_pw: hash.to_string(),
@@ -143,7 +158,8 @@ impl From<User> for DisplayUser {
     fn from(user: User) -> Self {
         DisplayUser {
             id: user.id,
-            name: user.name,
+            first_name: user.first_name,
+            last_name: user.last_name,
             email: user.email,
             phone: user.phone,
             created_at: user.created_at,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -70,20 +70,6 @@ table! {
 }
 
 table! {
-    organizations (id) {
-        id -> Uuid,
-        owner_user_id -> Uuid,
-        name -> Text,
-        address -> Nullable<Text>,
-        city -> Nullable<Text>,
-        state -> Nullable<Text>,
-        country -> Nullable<Text>,
-        zip -> Nullable<Text>,
-        phone -> Nullable<Text>,
-    }
-}
-
-table! {
     organization_users (id) {
         id -> Uuid,
         organization_id -> Uuid,
@@ -100,9 +86,24 @@ table! {
 }
 
 table! {
+    organizations (id) {
+        id -> Uuid,
+        owner_user_id -> Uuid,
+        name -> Text,
+        address -> Nullable<Text>,
+        city -> Nullable<Text>,
+        state -> Nullable<Text>,
+        country -> Nullable<Text>,
+        zip -> Nullable<Text>,
+        phone -> Nullable<Text>,
+    }
+}
+
+table! {
     users (id) {
         id -> Uuid,
-        name -> Text,
+        first_name -> Text,
+        last_name -> Text,
         email -> Nullable<Text>,
         phone -> Nullable<Text>,
         hashed_pw -> Text,
@@ -154,9 +155,9 @@ allow_tables_to_appear_in_same_query!(
     external_logins,
     orders,
     organization_invites,
-    organizations,
     organization_users,
     organization_venues,
+    organizations,
     users,
     venues,
 );

--- a/tests/support/user_builder.rs
+++ b/tests/support/user_builder.rs
@@ -4,7 +4,8 @@ use support::project::TestProject;
 use rand::prelude::*;
 
 pub struct UserBuilder<'a> {
-    name: String,
+    first_name: String,
+    last_name: String,
     email: String,
     phone: String,
     password: String,
@@ -12,11 +13,12 @@ pub struct UserBuilder<'a> {
 }
 
 impl<'a> UserBuilder<'a> {
-    pub fn new(test_project: &TestProject) -> UserBuilder {
+    pub fn new(test_project: &'a TestProject) -> Self {
         let x: u8 = random();
 
         UserBuilder {
-            name: "Jeff".into(),
+            first_name: "Jeff".into(),
+            last_name: "Wilco".into(),
             email: format!("jeff{}@tari.com", x).into(),
             phone: "555-555-5555".into(),
             password: "examplePassword".into(),
@@ -24,9 +26,24 @@ impl<'a> UserBuilder<'a> {
         }
     }
 
+    pub fn with_first_name(mut self, first_name: String) -> Self {
+        self.first_name = first_name;
+        self
+    }
+
+    pub fn with_last_name(mut self, last_name: String) -> Self {
+        self.last_name = last_name;
+        self
+    }
+
     pub fn finish(&self) -> User {
-        User::create(&self.name, &self.email, &self.phone, &self.password)
-            .commit(self.test_project)
+        User::create(
+            &self.first_name,
+            &self.last_name,
+            &self.email,
+            &self.phone,
+            &self.password,
+        ).commit(self.test_project)
             .unwrap()
     }
 }

--- a/tests/unit/concerns/users/password_resetable.rs
+++ b/tests/unit/concerns/users/password_resetable.rs
@@ -10,9 +10,7 @@ use uuid::Uuid;
 #[test]
 fn find_by_password_reset_token() {
     let project = TestProject::new();
-    let user = User::create("Jeff", "jeff@tari.com", "555-555-5555", "examplePassword")
-        .commit(&project)
-        .unwrap();
+    let user = project.create_user().finish();
     let user = user
         .create_password_reset_token(&project)
         .expect("Failed to create reset token");
@@ -39,9 +37,7 @@ fn find_by_password_reset_token() {
 fn consume_password_reset_token() {
     use bigneon_db::schema::users::dsl::*;
     let project = TestProject::new();
-    let user = User::create("Jeff", "jeff@tari.com", "555-555-5555", "examplePassword")
-        .commit(&project)
-        .unwrap();
+    let user = project.create_user().finish();
     let pw_modified_at = user.password_modified_at;
     let user: User = user
         .create_password_reset_token(&project)
@@ -99,9 +95,7 @@ fn consume_password_reset_token() {
 #[test]
 fn create_password_reset_token() {
     let project = TestProject::new();
-    let user = User::create("Jeff", "jeff@tari.com", "555-555-5555", "examplePassword")
-        .commit(&project)
-        .unwrap();
+    let user = project.create_user().finish();
     assert!(user.password_reset_token.is_none());
     assert!(user.password_reset_requested_at.is_none());
 
@@ -113,9 +107,7 @@ fn create_password_reset_token() {
 #[test]
 fn has_valid_password_reset_token() {
     let project = TestProject::new();
-    let mut user = User::create("Jeff", "jeff@tari.com", "555-555-5555", "examplePassword")
-        .commit(&project)
-        .unwrap();
+    let mut user = project.create_user().finish();
 
     // Expired token
     user.password_reset_token = Some(Uuid::new_v4());

--- a/tests/unit/users.rs
+++ b/tests/unit/users.rs
@@ -8,15 +8,17 @@ use uuid::Uuid;
 #[test]
 fn commit() {
     let project = TestProject::new();
-    let name = "Jeff";
+    let first_name = "Jeff";
+    let last_name = "Wilco";
     let email = "jeff@tari.com";
     let phone_number = "555-555-5555";
     let password = "examplePassword";
-    let user = User::create(name, email, phone_number, password)
+    let user = User::create(first_name, last_name, email, phone_number, password)
         .commit(&project)
         .unwrap();
 
-    assert_eq!(user.name, name);
+    assert_eq!(user.first_name, first_name);
+    assert_eq!(user.last_name, last_name);
     assert_eq!(user.email, Some(email.to_string()));
     assert_eq!(user.phone, Some(phone_number.to_string()));
     assert_ne!(user.hashed_pw, password);
@@ -28,11 +30,13 @@ fn commit() {
 fn commit_duplicate_email() {
     let project = TestProject::new();
     let user1 = project.create_user().finish();
-    let name = "Jeff";
+    let first_name = "Jeff";
+    let last_name = "Wilco";
     let email = &user1.email.unwrap();
     let phone_number = "555-555-5555";
     let password = "examplePassword";
-    let result = User::create(name, email, phone_number, password).commit(&project);
+    let result =
+        User::create(first_name, last_name, email, phone_number, password).commit(&project);
 
     assert_eq!(result.is_err(), true);
     assert_eq!(
@@ -60,14 +64,27 @@ fn find() {
 }
 
 #[test]
+fn full_name() {
+    let project = TestProject::new();
+
+    let first_name = "Bob".to_string();
+    let last_name = "Jones".to_string();
+
+    let user = project
+        .create_user()
+        .with_first_name(first_name.clone())
+        .with_last_name(last_name.clone())
+        .finish();
+    assert_eq!(user.full_name(), format!("{} {}", first_name, last_name));
+}
+
+#[test]
 fn find_by_email() {
     let project = TestProject::new();
-    let email = "jeff@tari.com";
-    let user = User::create("Jeff", email, "555-555-5555", "examplePassword")
-        .commit(&project)
-        .unwrap();
+    let user = project.create_user().finish();
 
-    let found_user = User::find_by_email(&email, &project).expect("User was not found");
+    let found_user =
+        User::find_by_email(&user.email.clone().unwrap(), &project).expect("User was not found");
     assert_eq!(found_user.unwrap(), user);
 
     assert!(


### PR DESCRIPTION
Related to https://github.com/big-neon/bn-api/issues/80

This is the bn-db side of changes to support this work. Simply breaks apart the name field into two different fields. Where possible I switched the logic to use the builders which simplified some of the test code as well.